### PR TITLE
MARS for MS-DOSからimportするデータのファイル名をMARS for MS-DOSのものに準拠

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,3 +1,3 @@
-resource/mars*
+resource/MARS*
 node_modules
 yarn.lock

--- a/data/README.md
+++ b/data/README.md
@@ -3,5 +3,5 @@
 
 # 使い方
 - http://www.swa.gr.jp/pub/mars/index.html から MARS for MS-DOSをダウンロードします．
-- `resource/` に 上に含まれる`mars_nn.dat`と`mars_sd.dat`を配置します．
+- `resource/` に 上に含まれる`MARS_NN.DAT`と`MARS_SD.DAT`を配置します．
 - `yarn run build` でdeimos内に`src/app/data.ts`が生成されます

--- a/data/build/Format.js
+++ b/data/build/Format.js
@@ -25,7 +25,7 @@ const output = {
     lines: [],
     stations: []
 };
-const dataSD = fs.readFileSync('./resource/mars_sd.dat');
+const dataSD = fs.readFileSync('./resource/MARS_SD.DAT');
 /**
  * 半角カタカナを全角ひらがなに変換
  * https://qiita.com/hrdaya/items/291276a5a20971592216
@@ -119,7 +119,7 @@ for (let r = 0; r < recordsNumSD; ++r) {
         line.stationIds.push(stationId);
     }
 }
-const dataNN = fs.readFileSync('./resource/mars_nn.dat');
+const dataNN = fs.readFileSync('./resource/MARS_NN.DAT');
 const recordsNum = dataNN.length / 8;
 for (let r = 0; r < recordsNum; ++r) {
     const offset = 8 * r;

--- a/data/src/Format.ts
+++ b/data/src/Format.ts
@@ -56,7 +56,7 @@ const output: OutputJSON = {
   lines: [],
   stations: []
 }
-const dataSD = fs.readFileSync('./resource/mars_sd.dat')
+const dataSD = fs.readFileSync('./resource/MARS_SD.DAT')
 /**
  * 半角カタカナを全角ひらがなに変換
  * https://qiita.com/hrdaya/items/291276a5a20971592216
@@ -154,7 +154,7 @@ for (let r = 0; r < recordsNumSD; ++r) {
   }
 }
 
-const dataNN = fs.readFileSync('./resource/mars_nn.dat')
+const dataNN = fs.readFileSync('./resource/MARS_NN.DAT')
 const recordsNum = dataNN.length / 8
 
 for (let r = 0; r < recordsNum; ++r) {


### PR DESCRIPTION
MARS for MS-DOSからimportする`mars_nn.dat`と`mars_sd.dat`がMARS for MS-DOSでは大文字表記になっていたため、それに合わせてプログラムを変更しました。